### PR TITLE
improve errors handling

### DIFF
--- a/src/extensionProvider.ts
+++ b/src/extensionProvider.ts
@@ -125,17 +125,21 @@ export class ExtensionProvider {
   async signTransactions(transactions: Transaction[]): Promise<Transaction[]> {
     this.ensureConnected();
 
-    const extensionResponse = await this.startBgrMsgChannel(
-      Operation.SignTransactions,
-      {
-        from: this.account.address,
-        transactions: transactions.map((transaction) =>
-          transaction.toPlainObject()
-        ),
-      }
-    );
-
     try {
+      const extensionResponse = await this.startBgrMsgChannel(
+        Operation.SignTransactions,
+        {
+          from: this.account.address,
+          transactions: transactions.map((transaction) =>
+            transaction.toPlainObject()
+          ),
+        }
+      );
+
+      if (!Array.isArray(extensionResponse)) {
+        throw new Error(extensionResponse?.name || JSON.stringify(extensionResponse));
+      }
+
       const transactionsResponse = extensionResponse.map(
         (transaction: IPlainTransactionObject) =>
           Transaction.fromPlainObject(transaction)
@@ -143,7 +147,7 @@ export class ExtensionProvider {
 
       return transactionsResponse;
     } catch (error: any) {
-      throw new Error(`Transaction canceled: ${error.message}.`);
+      throw new Error(`Transaction failed${error.message ? `: ${error.message}` : '.'}`);
     }
   }
 


### PR DESCRIPTION
There could be a better way to improve that. Maybe on the message event listeners' side, but this change makes the errors more readable. 

1. Change the main message to 'Transaction failed' instead of 'Transaction canceled,' which is more general
2. Spread the try catch also for `startBgrMsgChannel` Promise
3. Catch the `extensionResponse` when it is not an array of transactions. When someone cancels the process.

Instead:
```
Transaction canceled: extensionResponse.map is not a function.
```
We now have:
```
Transaction failed: CanceledError.
```